### PR TITLE
fix: guard WriteSymbolDirect against null frameLookup

### DIFF
--- a/DuplicantStatusBar/UI/PortraitCompositor.cs
+++ b/DuplicantStatusBar/UI/PortraitCompositor.cs
@@ -209,8 +209,11 @@ namespace DuplicantStatusBar.UI
             if (usePivot)
             {
                 var frame = symbol.GetFrame(frameIdx);
-                pivotX = Mathf.RoundToInt(frame.bboxMin.x + source.width);
-                pivotY = Mathf.RoundToInt(frame.bboxMin.y + source.height);
+                if (!frame.Equals(default(KAnim.Build.SymbolFrameInstance)))
+                {
+                    pivotX = Mathf.RoundToInt(frame.bboxMin.x + source.width);
+                    pivotY = Mathf.RoundToInt(frame.bboxMin.y + source.height);
+                }
             }
             int xStart = (output.width / 2) - (source.width / 2) + xOffset;
             int yStart;

--- a/DuplicantStatusBar/UI/PortraitCompositor.cs
+++ b/DuplicantStatusBar/UI/PortraitCompositor.cs
@@ -176,7 +176,8 @@ namespace DuplicantStatusBar.UI
             VerticalAnchor anchor = VerticalAnchor.Center,
             float rotation = 0f)
         {
-            if (symbol == null) return;
+            if (symbol == null || symbol.frameLookup == null || symbol.frameLookup.Length == 0)
+                return;
 
             int frameIdx = frameOverride >= 0 ? frameOverride : 0;
             if (frameIdx >= symbol.frameLookup.Length)


### PR DESCRIPTION
## Summary
- Adds null/empty check for `symbol.frameLookup` in `WriteSymbolDirect` to prevent NullReferenceException
- The downstream `GetSpriteFromSymbol` already had this guard, but the caller accessed `frameLookup.Length` before reaching it
- Fixes #10

## Test plan
- [ ] Load a save with bionic and non-bionic dupes in portrait mode
- [ ] Verify no NRE in Player.log during portrait compositing
- [ ] Confirm portraits render correctly for all accessory types